### PR TITLE
fix: Update the Little Luggable keymaps

### DIFF
--- a/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
+++ b/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
@@ -2,18 +2,72 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/keys.h>
 
+#define LOWER 1
+#define RAISE 2
+
 / {
+
+    behaviors {
+
+        dotqmark: dot_question {
+            compatible = "zmk,behavior-mod-morph";
+            label = "DOT_QUESTION";
+            #binding-cells = <0>;
+            bindings = <&kp DOT>, <&kp QUESTION>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
+        };
+
+        commaslash: comma_slash {
+            compatible = "zmk,behavior-mod-morph";
+            label = "COMMA_SLASH";
+            #binding-cells = <0>;
+            bindings = <&kp COMMA>, <&kp SLASH>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
+        };
+
+    };
+
     keymap {
         compatible = "zmk,keymap";
 
         default_layer {
 
             bindings = <
-                &kp A                    &kp BACKSPACE
-                              &kp SPACE
-                &bt BT_SEL 1             &bt BT_CLR
+                &kp ESC   &kp F1    &kp F2    &kp F3    &kp F4    &kp F5    &kp F6    &kp F7    &kp F8    &kp F9    &kp F10
+                  &kp N1    &kp N2    &kp N3    &kp N4    &kp N5    &kp N6    &kp N7    &kp N8    &kp N9    &kp N0    &kp BSPC
+                &kp TAB   &kp Q     &kp W     &kp E     &kp R     &kp T     &kp Y     &kp U     &kp I     &kp O     &kp P
+                  &kp LCTRL &kp A     &kp S     &kp D     &kp F     &kp G     &kp H     &kp J     &kp K     &kp L     &kp RET
+                    &kp LSHFT &kp Z    &kp X    &kp C    &kp V    &kp B    &kp N    &kp M    &dotqmark  &kp RSHFT
+                &kp LCTRL   &mo LOWER   &mo RAISE   &kp LALT    &kp LGUI    &kp SPACE   &kp LEFT    &kp DOWN    &kp UP      &kp RIGHT
             >;
 
         };
+
+        lower_layer {
+
+            bindings = <
+                &bt BT_SEL 0    &bt BT_SEL 1     &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4    &none    &none    &none    &none    &none    &bt BT_CLR
+                  &none    &none     &none    &none    &none    &none    &none    &none    &none    &none    &none
+                &none    &none     &none    &none    &none    &none    &none    &none    &none    &none    &none
+                  &none    &none     &none    &none    &none    &none    &none    &none    &none    &none    &none
+                    &none    &none     &none    &none    &none    &none    &none    &none    &none    &none
+                &none    &none     &none    &none    &none    &none    &none    &none    &none    &none
+            >;
+
+        };
+
+        raise_layer {
+
+            bindings = <
+                &kp ESC    &none    &none    &none    &none    &none    &none    &none    &none    &kp F11    &kp F12
+                  &kp GRAVE    &none     &none    &none    &none    &none    &none    &none    &kp MINUS    &kp EQUAL    &none
+                &none    &none    &none    &none    &none    &none    &none    &none    &kp LBKT    &kp RBKT    &kp BSLH
+                  &none    &none     &none    &none    &none    &none    &none    &none    &kp SEMI    &kp APOS    &none
+                    &kp LSHFT  &none     &none    &none    &none    &none    &kp LT    &kp GT    &commaslash    &kp RSHFT
+                &kp LCTRL    &none     &none    &kp LALT    &kp LGUI    &kp SPACE    &none    &none    &none    &none
+            >;
+
+        };
+
     };
 };

--- a/keyboard-firmware/boards/shields/little_luggable/little_luggable.overlay
+++ b/keyboard-firmware/boards/shields/little_luggable/little_luggable.overlay
@@ -12,26 +12,39 @@
         diode-direction = "col2row";
 
         col-gpios
-            = <&pro_micro 15 GPIO_ACTIVE_HIGH>
+            = <&pro_micro 21 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 20 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 19 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 18 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 15 GPIO_ACTIVE_HIGH>
             , <&pro_micro 14 GPIO_ACTIVE_HIGH>
             , <&pro_micro 16 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 10 GPIO_ACTIVE_HIGH>
             ;
 
         row-gpios
-            = <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            = <&pro_micro 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
     };
 
     default_transform: matrix_transform {
         compatible = "zmk,matrix-transform";
-        columns = <3>;
-        rows = <3>;
+        columns = <11>;
+        rows = <6>;
         map = <
-            RC(0,0)         RC(0,2)
-                    RC(1,1)
-            RC(2,0)         RC(2,2)
+            RC(0,0)     RC(1,0)     RC(2,0)     RC(3,0)     RC(4,0)     RC(5,0)     RC(6,0)     RC(7,0)     RC(0,6)     RC(0,7)     RC(7,7)
+                RC(0,1)     RC(1,1)     RC(2,1)     RC(3,1)     RC(4,1)     RC(5,1)     RC(6,1)     RC(7,1)     RC(1,6)     RC(1,7)     RC(6,7)
+            RC(0,2)     RC(1,2)     RC(2,2)     RC(3,2)     RC(4,2)     RC(5,2)     RC(6,2)     RC(7,2)     RC(2,6)     RC(2,7)     RC(5,7)
+                RC(0,3)     RC(1,3)     RC(2,3)     RC(3,3)     RC(4,3)     RC(5,3)     RC(6,3)     RC(7,3)     RC(3,6)     RC(3,7)     RC(4,7)
+                    RC(0,4)     RC(1,4)     RC(2,4)     RC(3,4)     RC(4,4)     RC(5,4)     RC(6,4)     RC(7,4)     RC(4,6)     RC(7,6)
+            RC(0,5)     RC(1,5)     RC(2,5)     RC(3,5)     RC(4,5)           RC(5,5)           RC(6,5)     RC(7,5)     RC(5,6)     RC(6,6)
         >;
     };
 


### PR DESCRIPTION
This change catches this repository up to the version of the firmware from the Little Luggable repository. Long-term this repository probably shouldn't include the Little Luggable keyboard firmware at all.